### PR TITLE
Fix dialyzer errors under OTP R15B01

### DIFF
--- a/src/lhttpc_manager.erl
+++ b/src/lhttpc_manager.erl
@@ -124,7 +124,7 @@ init(Options) ->
         true ->
             % Make sure that the ssl random number generator is seeded
             % This was new in R13 (ssl-3.10.1 in R13B vs. ssl-3.10.0 in R12B-5)
-            ssl:seed(crypto:rand_bytes(255));
+            apply(ssl, seed, [crypto:rand_bytes(255)]);
         false ->
             ok
     end,
@@ -218,9 +218,9 @@ terminate(_, State) ->
     close_sockets(State#httpc_man.sockets).
 
 %% @hidden
--spec code_change(any(), #httpc_man{}, any()) -> #httpc_man{}.
+-spec code_change(any(), #httpc_man{}, any()) -> {'ok', #httpc_man{}}.
 code_change(_, State, _) ->
-    State.
+    {ok, State}.
 
 find_socket({_, _, Ssl} = Dest, Pid, State) ->
     Dests = State#httpc_man.destinations,

--- a/src/lhttpc_sup.erl
+++ b/src/lhttpc_sup.erl
@@ -35,9 +35,6 @@
 -export([start_link/0]).
 -export([init/1]).
 
--type child() :: {atom(), {atom(), atom(), list(any)},
-    atom(), integer(), atom(), list(atom())}.
-
 %% @spec () -> {ok, pid()} | {error, Reason}
 %% Reason = atom()
 %% @doc Starts and links to the supervisor.
@@ -49,7 +46,6 @@ start_link() ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).
 
 %% @hidden
--spec init(any()) -> {ok, {{atom(), integer(), integer()}, [child()]}}.
 init(_) ->
     LHTTPCManager = {lhttpc_manager, {lhttpc_manager, start_link, [[{name, lhttpc_manager}]]},
         permanent, 10000, worker, [lhttpc_manager]


### PR DESCRIPTION
$ make dialyzer
./rebar analyze
==> lhttpc-1 (analyze)
lhttpc_manager.erl:127: Call to missing or unexported function ssl:seed/1
lhttpc_manager.erl:221: The return type #httpc_man{max_pool_size::non_neg_integer(),timeout::non_neg_integer()} in the specification of code_change/3 is not a subtype of {'error',_} | {'ok',_}, which is the expected return type for the callback of gen_server behaviour
lhttpc_sup.erl:52: The return type {'ok',{{atom(),integer(),integer()},[{atom(),{atom(),atom(),['any']},atom(),integer(),atom(),[atom()]}]}} in the specification of init/1 is not a subtype of 'ignore' | {'ok',{{'one_for_all',non_neg_integer(),non_neg_integer()} | {'one_for_one',non_neg_integer(),non_neg_integer()} | {'rest_for_one',non_neg_integer(),non_neg_integer()} | {'simple_one_for_one',non_neg_integer(),non_neg_integer()},[{_,{atom() | tuple(),atom(),'undefined' | [any()]},'permanent' | 'temporary' | 'transient','brutal_kill' | 'infinity' | non_neg_integer(),'supervisor' | 'worker','dynamic' | [atom() | tuple()]}]}}, which is the expected return type for the callback of supervisor behaviour
$
