### PR TITLE
Handling url-encoded credentials in http urls

### DIFF
--- a/src/lhttpc_lib.erl
+++ b/src/lhttpc_lib.erl
@@ -133,9 +133,9 @@ split_credentials(CredsHostPortPath) ->
             case string:tokens(Creds, ":") of
                 [User] ->
                     % RFC1738 says ":password" is optional
-                    {User, "", HostPortPath};
+                    {http_uri:decode(User), "", HostPortPath};
                 [User, Passwd] ->
-                    {User, Passwd, HostPortPath}
+                    {http_uri:decode(User), http_uri:decode(Passwd), HostPortPath}
             end
     end.
 

--- a/test/lhttpc_lib_tests.erl
+++ b/test/lhttpc_lib_tests.erl
@@ -123,6 +123,17 @@ parse_url_test_() ->
                         },
                       lhttpc_lib:parse_url("http://joe:erlang@host:180/foo/bar")),
 
+
+        ?_assertEqual(#lhttpc_url{
+                         host = "host",
+                         port = 180,
+                         path = "/foo/bar",
+                         is_ssl = false,
+                         user = "joe",
+                         password = "erl@ng"
+                        },
+                      lhttpc_lib:parse_url("http://joe:erl%40ng@host:180/foo/bar")),
+
         ?_assertEqual(#lhttpc_url{
                          host = "host",
                          port = 180,
@@ -148,7 +159,7 @@ parse_url_test_() ->
                          port = 180,
                          path = "/foo/bar",
                          is_ssl = false,
-                         user = "joe%3Aarm",
+                         user = "joe:arm",
                          password = "erlang"
                         },
                       lhttpc_lib:parse_url("http://joe%3Aarm:erlang@host:180/foo/bar")),
@@ -158,8 +169,8 @@ parse_url_test_() ->
                          port = 180,
                          path = "/foo/bar",
                          is_ssl = false,
-                         user = "joe%3aarm",
-                         password = "erlang%2Fotp"
+                         user = "joe:arm",
+                         password = "erlang/otp"
                         },
                       lhttpc_lib:parse_url("http://joe%3aarm:erlang%2Fotp@host:180/foo/bar")),
 


### PR DESCRIPTION
Comments in split_credentials correctly indicate that any special
chars need to be 'percent-encoded'. So in order to get their true
values we need to un-encode.

Otherwise there's simply no way to use usernames/passwords with
special characters when doing basic auth via urls.
