### PR TITLE
handle {ok,{http_error,_}} return in lhttpc_client:read_response()

### DIFF
--- a/src/lhttpc_client.erl
+++ b/src/lhttpc_client.erl
@@ -391,6 +391,8 @@ read_response(State, Vsn, {StatusCode, _} = Status, Hdrs) ->
                 attempts = State#client_state.attempts - 1
             },
             send_request(NewState);
+	{ok, {http_error, _} = Reason} ->
+	    erlang:error(Reason);
         {error, Reason} ->
             erlang:error(Reason)
     end.


### PR DESCRIPTION
{ok, {http_error, ...}} is a valid response, and should be handled.
