### PR TITLE
Handle URLs where the query part follows the hostname without a slash in between

### DIFF
--- a/src/lhttpc_lib.erl
+++ b/src/lhttpc_lib.erl
@@ -254,6 +254,11 @@ split_host([$: | PortPath], Host) ->
     {lists:reverse(Host), PortPath};
 split_host([$/ | _] = PortPath, Host) ->
     {lists:reverse(Host), PortPath};
+split_host([$? | _] = Query, Host) ->
+    %% The query string follows the hostname, without a slash.  The
+    %% path is empty, but for HTTP an empty path is equivalent to "/"
+    %% (RFC 3986, section 6.2.3), so let's add the slash ourselves.
+    {lists:reverse(Host), "/" ++ Query};
 split_host([H | T], Host) ->
     split_host(T, [H | Host]);
 split_host([], Host) ->

--- a/test/lhttpc_lib_tests.erl
+++ b/test/lhttpc_lib_tests.erl
@@ -212,5 +212,15 @@ parse_url_test_() ->
                          user = "joe",
                          password = "erlang"
                         },
-                      lhttpc_lib:parse_url("http://joe:erlang@[1080:0:0:0:8:800:200C:417A]:180/foo/bar"))
+                      lhttpc_lib:parse_url("http://joe:erlang@[1080:0:0:0:8:800:200C:417A]:180/foo/bar")),
+
+        ?_assertEqual(#lhttpc_url{
+                         host = "www.example.com",
+                         port = 80,
+                         path = "/?a=b",
+                         is_ssl = false,
+                         user = "",
+                         password = ""
+                        },
+                      lhttpc_lib:parse_url("http://www.example.com?a=b"))
     ].


### PR DESCRIPTION
For example, in http://www.example.com?a=b the hostname is "www.example.com", not "www.example.com?a=b".  See RFC 3986, section 3.
