### PR TITLE
catch both 'error' and 'exit'

### DIFF
--- a/src/lhttpc_client.erl
+++ b/src/lhttpc_client.erl
@@ -95,7 +95,7 @@ request(From, Host, Port, Ssl, Path, Method, Hdrs, Body, Options) ->
             {response, self(), {error, Reason}};
         error:closed ->
             {response, self(), {error, connection_closed}};
-        error:Reason ->
+        Class:Reason when Class == error; Class == exit ->
             Stack = erlang:get_stacktrace(),
             {response, self(), {error, {Reason, Stack}}}
     end,


### PR DESCRIPTION
Prevent death of a process calling lhttpc:request when request execution dies with 'exit'. When calling process is not trapping exits it'll die because it's linked to the process executing request.
