### PR TITLE
fixed handling connection-length with transfer-encoding: chunked

### DIFF
--- a/src/lhttpc_client.erl
+++ b/src/lhttpc_client.erl
@@ -537,17 +537,18 @@ has_body(_, _, _) ->
 %%------------------------------------------------------------------------------
 -spec body_type(headers()) -> 'chunked' | 'infinite' | {fixed_length, integer()}.
 body_type(Hdrs) ->
-    case lhttpc_lib:header_value("content-length", Hdrs) of
-        undefined ->
-            TransferEncoding = string:to_lower(
-                lhttpc_lib:header_value("transfer-encoding", Hdrs, "undefined")
-            ),
-            case TransferEncoding of
-                "chunked" -> chunked;
-                _         -> infinite
-            end;
-        ContentLength ->
-            {fixed_length, list_to_integer(ContentLength)}
+    TransferEncoding = string:to_lower(
+        lhttpc_lib:header_value("transfer-encoding", Hdrs, "undefined")
+    ),
+    case TransferEncoding of
+        "chunked" -> chunked;
+        _ ->
+            case lhttpc_lib:header_value("content-length", Hdrs) of
+                undefined -> 
+                    infinite;
+                ContentLength ->
+                    {fixed_length, list_to_integer(ContentLength)}
+            end
     end.
 
 %%------------------------------------------------------------------------------

--- a/test/lhttpc_manager_tests.erl
+++ b/test/lhttpc_manager_tests.erl
@@ -36,6 +36,7 @@
 %%% Eunit setup stuff
 
 start_app() ->
+    application:start(asn1),
     application:start(public_key),
     ok = application:start(ssl),
     _ = application:load(lhttpc),


### PR DESCRIPTION
When both transfer-encoding: chunked and content-length are specified, lhttpc behaves wrong (as I think): it just downloads some bytes and that's all.

It is wrong, because transfer-encoding: chunked means that "content-length" bytes are packed with transfer-encoding chunked.

I've changed order of checks in lhttpc_client and added proper test.
