### PR TITLE
fixes to compile under Erlang 17.0-rc2

### DIFF
--- a/doc/overview.edoc
+++ b/doc/overview.edoc
@@ -1,4 +1,4 @@
-@author Oscar Hellström <oscar@hellstrom.st>
+@author Oscar HellstrÃ¶m <oscar@hellstrom.st>
 @doc A lightweight HTTP client.
 The only functions of much interest right now are {@link
 lhttpc:request/4}, {@link lhttpc:request/5}, {@link lhttpc:request/6} and

--- a/src/lhttpc.app.src
+++ b/src/lhttpc.app.src
@@ -24,7 +24,7 @@
 %%% ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 %%% ----------------------------------------------------------------------------
 
-%%% @author Oscar Hellström <oscar@hellstrom.st>
+%%% @author Oscar HellstrÃ¶m <oscar@hellstrom.st>
 %%% @doc This is the specification for the lhttpc application.
 %%% @end
 {application, lhttpc,

--- a/src/lhttpc.erl
+++ b/src/lhttpc.erl
@@ -25,7 +25,7 @@
 %%% ----------------------------------------------------------------------------
 
 %%------------------------------------------------------------------------------
-%%% @author Oscar Hellström <oscar@hellstrom.st>
+%%% @author Oscar HellstrÃ¶m <oscar@hellstrom.st>
 %%% @doc Main interface to the lightweight http client.
 %%% See {@link request/4}, {@link request/5} and {@link request/6} functions.
 %%% @end

--- a/src/lhttpc_client.erl
+++ b/src/lhttpc_client.erl
@@ -26,7 +26,7 @@
 
 %%------------------------------------------------------------------------------
 %%% @private
-%%% @author Oscar Hellström <oscar@hellstrom.st>
+%%% @author Oscar HellstrÃ¶m <oscar@hellstrom.st>
 %%% @doc This module implements the HTTP request handling. This should normally
 %%% not be called directly since it should be spawned by the lhttpc module.
 %%% @end

--- a/src/lhttpc_lib.erl
+++ b/src/lhttpc_lib.erl
@@ -26,7 +26,7 @@
 
 %%------------------------------------------------------------------------------
 %%% @private
-%%% @author Oscar Hellström <oscar@hellstrom.st>
+%%% @author Oscar HellstrÃ¶m <oscar@hellstrom.st>
 %%% @doc
 %%% This module implements various library functions used in lhttpc.
 %%------------------------------------------------------------------------------

--- a/src/lhttpc_manager.erl
+++ b/src/lhttpc_manager.erl
@@ -25,7 +25,7 @@
 %%% ----------------------------------------------------------------------------
 
 %%------------------------------------------------------------------------------
-%%% @author Oscar Hellström <oscar@hellstrom.st>
+%%% @author Oscar HellstrÃ¶m <oscar@hellstrom.st>
 %%% @author Filipe David Manana <fdmanana@apache.org>
 %%% @doc Connection manager for the HTTP client.
 %%% This gen_server is responsible for keeping track of persistent

--- a/src/lhttpc_sock.erl
+++ b/src/lhttpc_sock.erl
@@ -26,7 +26,7 @@
 
 %%------------------------------------------------------------------------------
 %%% @private
-%%% @author Oscar Hellström <oscar@hellstrom.st>
+%%% @author Oscar HellstrÃ¶m <oscar@hellstrom.st>
 %%% @doc
 %%% This module implements wrappers for socket operations.
 %%% Makes it possible to have the same interface to ssl and tcp sockets.

--- a/src/lhttpc_sup.erl
+++ b/src/lhttpc_sup.erl
@@ -25,7 +25,7 @@
 %%% ----------------------------------------------------------------------------
 
 %%------------------------------------------------------------------------------
-%%% @author Oscar Hellström <oscar@hellstrom.st>
+%%% @author Oscar HellstrÃ¶m <oscar@hellstrom.st>
 %%% @doc Top supervisor for the lhttpc application.
 %%% This is normally started by the application behaviour implemented in
 %%% {@link lhttpc}.

--- a/test/lhttpc_lib_tests.erl
+++ b/test/lhttpc_lib_tests.erl
@@ -24,7 +24,7 @@
 %%% ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 %%% ----------------------------------------------------------------------------
 
-%%% @author Oscar Hellström <oscar@hellstrom.st>
+%%% @author Oscar HellstrÃ¶m <oscar@hellstrom.st>
 -module(lhttpc_lib_tests).
 
 -include("../include/lhttpc_types.hrl").

--- a/test/lhttpc_manager_tests.erl
+++ b/test/lhttpc_manager_tests.erl
@@ -24,7 +24,7 @@
 %%% ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 %%% ----------------------------------------------------------------------------
 
-%%% @author Oscar Hellström <oscar@hellstrom.st>
+%%% @author Oscar HellstrÃ¶m <oscar@hellstrom.st>
 %%% @author Filipe David Manana <fdmanana@apache.org>
 -module(lhttpc_manager_tests).
 
@@ -36,6 +36,8 @@
 %%% Eunit setup stuff
 
 start_app() ->
+	application:start(crypto),
+	application:start(asn1),
     application:start(public_key),
     ok = application:start(ssl),
     _ = application:load(lhttpc),

--- a/test/lhttpc_tests.erl
+++ b/test/lhttpc_tests.erl
@@ -24,7 +24,7 @@
 %%% ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 %%% ----------------------------------------------------------------------------
 
-%%% @author Oscar Hellström <oscar@hellstrom.st>
+%%% @author Oscar HellstrÃ¶m <oscar@hellstrom.st>
 -module(lhttpc_tests).
 
 -export([test_no/2]).
@@ -100,6 +100,7 @@ test_no(N, Tests) ->
 
 start_app() ->
     application:start(crypto),
+    application:start(asn1),
     application:start(public_key),
     ok = application:start(ssl),
     ok = lhttpc:start().

--- a/test/socket_server.erl
+++ b/test/socket_server.erl
@@ -24,7 +24,7 @@
 %%% ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 %%% ----------------------------------------------------------------------------
 
-%%% @author Oscar Hellström <oscar@hellstrom.st>
+%%% @author Oscar HellstrÃ¶m <oscar@hellstrom.st>
 -module(socket_server).
 
 -export([connect/1, listen/0, accept/1]).

--- a/test/webserver.erl
+++ b/test/webserver.erl
@@ -24,7 +24,7 @@
 %%% ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 %%% ----------------------------------------------------------------------------
 
-%%% @author Oscar Hellström <oscar@hellstrom.st>
+%%% @author Oscar HellstrÃ¶m <oscar@hellstrom.st>
 %%% @author Magnus Henoch <magnus@erlang-consulting.com>
 %%% @doc Simple web server for testing purposes
 %%% @end

--- a/util/make_doc.erl
+++ b/util/make_doc.erl
@@ -24,7 +24,7 @@
 %%% ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 %%% ----------------------------------------------------------------------------
 
-%%% @author Oscar Hellström <oscar@hellstrom.st>
+%%% @author Oscar HellstrÃ¶m <oscar@hellstrom.st>
 -module(make_doc).
 -export([edoc/0]).
 

--- a/util/run_test.erl
+++ b/util/run_test.erl
@@ -24,7 +24,7 @@
 %%% ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 %%% ----------------------------------------------------------------------------
 
-%%% @author Oscar Hellström <oscar@hellstrom.st>
+%%% @author Oscar HellstrÃ¶m <oscar@hellstrom.st>
 -module(run_test).
 -export([run/0]).
 


### PR DESCRIPTION
Modified files with Oscar Hellström's name to be UTF-8. This stops the compiler from choking on the file. Fixes #42 and fixes #35

Added a `application:start(asn1)` before public_key in eunit tests. This was causing some test failures.

With these changes, lhttpc compiles and passes all tests for me under Erlang 17.0-rc2 on Mac OS X 10.9.2.
