### PR TITLE
Non-intrusive encoding fixes for Erlang 17.0

### DIFF
--- a/src/lhttpc.app.src
+++ b/src/lhttpc.app.src
@@ -1,3 +1,4 @@
+%%% -*- coding: latin-1 -*-
 %%% ----------------------------------------------------------------------------
 %%% Copyright (c) 2009, Erlang Training and Consulting Ltd.
 %%% All rights reserved.

--- a/src/lhttpc.erl
+++ b/src/lhttpc.erl
@@ -1,3 +1,4 @@
+%%% -*- coding: latin-1 -*-
 %%% ----------------------------------------------------------------------------
 %%% Copyright (c) 2009, Erlang Training and Consulting Ltd.
 %%% All rights reserved.

--- a/src/lhttpc_client.erl
+++ b/src/lhttpc_client.erl
@@ -1,3 +1,4 @@
+%%% -*- coding: latin-1 -*-
 %%% ----------------------------------------------------------------------------
 %%% Copyright (c) 2009, Erlang Training and Consulting Ltd.
 %%% All rights reserved.

--- a/src/lhttpc_lib.erl
+++ b/src/lhttpc_lib.erl
@@ -1,3 +1,4 @@
+%%% -*- coding: latin-1 -*-
 %%% ----------------------------------------------------------------------------
 %%% Copyright (c) 2009, Erlang Training and Consulting Ltd.
 %%% All rights reserved.

--- a/src/lhttpc_manager.erl
+++ b/src/lhttpc_manager.erl
@@ -1,3 +1,4 @@
+%%% -*- coding: latin-1 -*-
 %%% ----------------------------------------------------------------------------
 %%% Copyright (c) 2009, Erlang Training and Consulting Ltd.
 %%% All rights reserved.

--- a/src/lhttpc_sock.erl
+++ b/src/lhttpc_sock.erl
@@ -1,3 +1,4 @@
+%%% -*- coding: latin-1 -*-
 %%% ----------------------------------------------------------------------------
 %%% Copyright (c) 2009, Erlang Training and Consulting Ltd.
 %%% All rights reserved.

--- a/src/lhttpc_sup.erl
+++ b/src/lhttpc_sup.erl
@@ -1,3 +1,4 @@
+%%% -*- coding: latin-1 -*-
 %%% ----------------------------------------------------------------------------
 %%% Copyright (c) 2009, Erlang Training and Consulting Ltd.
 %%% All rights reserved.

--- a/test/lhttpc_lib_tests.erl
+++ b/test/lhttpc_lib_tests.erl
@@ -1,3 +1,4 @@
+%%% -*- coding: latin-1 -*-
 %%% ----------------------------------------------------------------------------
 %%% Copyright (c) 2009, Erlang Training and Consulting Ltd.
 %%% All rights reserved.

--- a/test/lhttpc_manager_tests.erl
+++ b/test/lhttpc_manager_tests.erl
@@ -1,3 +1,4 @@
+%%% -*- coding: latin-1 -*-
 %%% ----------------------------------------------------------------------------
 %%% Copyright (c) 2009, Erlang Training and Consulting Ltd.
 %%% All rights reserved.

--- a/test/lhttpc_tests.erl
+++ b/test/lhttpc_tests.erl
@@ -1,3 +1,4 @@
+%%% -*- coding: latin-1 -*-
 %%% ----------------------------------------------------------------------------
 %%% Copyright (c) 2009, Erlang Training and Consulting Ltd.
 %%% All rights reserved.

--- a/test/simple_load.erl
+++ b/test/simple_load.erl
@@ -1,3 +1,4 @@
+%%% -*- coding: latin-1 -*-
 -module(simple_load).
 -behaviour(gen_httpd).
 

--- a/test/socket_server.erl
+++ b/test/socket_server.erl
@@ -1,3 +1,4 @@
+%%% -*- coding: latin-1 -*-
 %%% ----------------------------------------------------------------------------
 %%% Copyright (c) 2009, Erlang Training and Consulting Ltd.
 %%% All rights reserved.

--- a/test/webserver.erl
+++ b/test/webserver.erl
@@ -1,3 +1,4 @@
+%%% -*- coding: latin-1 -*-
 %%% ----------------------------------------------------------------------------
 %%% Copyright (c) 2009, Erlang Training and Consulting Ltd.
 %%% All rights reserved.


### PR DESCRIPTION
This adds proper encoding hints for Erlang 17.0 (and R16) that enables lhttpc to be compiled.

This is an alternative to #43 and #44. Depends on #38 being merged to be able to be tested.
