### PR TITLE
Start asn1 in tests

### DIFF
--- a/test/lhttpc_manager_tests.erl
+++ b/test/lhttpc_manager_tests.erl
@@ -36,6 +36,7 @@
 %%% Eunit setup stuff
 
 start_app() ->
+    application:start(asn1),
     application:start(public_key),
     ok = application:start(ssl),
     _ = application:load(lhttpc),

--- a/test/lhttpc_tests.erl
+++ b/test/lhttpc_tests.erl
@@ -99,6 +99,7 @@ test_no(N, Tests) ->
 %%% Eunit setup stuff
 
 start_app() ->
+    application:start(asn1),
     application:start(crypto),
     application:start(public_key),
     ok = application:start(ssl),


### PR DESCRIPTION
Tests currently fail on R16B03 because the `asn1` application
was not started. `public_key` needs this application to run.
