### PR TITLE
Convert sources to utf-8.

### DIFF
--- a/src/lhttpc.app.src
+++ b/src/lhttpc.app.src
@@ -24,7 +24,7 @@
 %%% ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 %%% ----------------------------------------------------------------------------
 
-%%% @author Oscar Hellström <oscar@hellstrom.st>
+%%% @author Oscar HellstrÃ¶m <oscar@hellstrom.st>
 %%% @doc This is the specification for the lhttpc application.
 %%% @end
 {application, lhttpc,

--- a/src/lhttpc.erl
+++ b/src/lhttpc.erl
@@ -25,7 +25,7 @@
 %%% ----------------------------------------------------------------------------
 
 %%------------------------------------------------------------------------------
-%%% @author Oscar Hellström <oscar@hellstrom.st>
+%%% @author Oscar HellstrÃ¶m <oscar@hellstrom.st>
 %%% @doc Main interface to the lightweight http client.
 %%% See {@link request/4}, {@link request/5} and {@link request/6} functions.
 %%% @end

--- a/src/lhttpc_client.erl
+++ b/src/lhttpc_client.erl
@@ -26,7 +26,7 @@
 
 %%------------------------------------------------------------------------------
 %%% @private
-%%% @author Oscar Hellström <oscar@hellstrom.st>
+%%% @author Oscar HellstrÃ¶m <oscar@hellstrom.st>
 %%% @doc This module implements the HTTP request handling. This should normally
 %%% not be called directly since it should be spawned by the lhttpc module.
 %%% @end

--- a/src/lhttpc_lib.erl
+++ b/src/lhttpc_lib.erl
@@ -26,7 +26,7 @@
 
 %%------------------------------------------------------------------------------
 %%% @private
-%%% @author Oscar Hellström <oscar@hellstrom.st>
+%%% @author Oscar HellstrÃ¶m <oscar@hellstrom.st>
 %%% @doc
 %%% This module implements various library functions used in lhttpc.
 %%------------------------------------------------------------------------------

--- a/src/lhttpc_manager.erl
+++ b/src/lhttpc_manager.erl
@@ -25,7 +25,7 @@
 %%% ----------------------------------------------------------------------------
 
 %%------------------------------------------------------------------------------
-%%% @author Oscar Hellström <oscar@hellstrom.st>
+%%% @author Oscar HellstrÃ¶m <oscar@hellstrom.st>
 %%% @author Filipe David Manana <fdmanana@apache.org>
 %%% @doc Connection manager for the HTTP client.
 %%% This gen_server is responsible for keeping track of persistent

--- a/src/lhttpc_sock.erl
+++ b/src/lhttpc_sock.erl
@@ -26,7 +26,7 @@
 
 %%------------------------------------------------------------------------------
 %%% @private
-%%% @author Oscar Hellström <oscar@hellstrom.st>
+%%% @author Oscar HellstrÃ¶m <oscar@hellstrom.st>
 %%% @doc
 %%% This module implements wrappers for socket operations.
 %%% Makes it possible to have the same interface to ssl and tcp sockets.

--- a/src/lhttpc_sup.erl
+++ b/src/lhttpc_sup.erl
@@ -25,7 +25,7 @@
 %%% ----------------------------------------------------------------------------
 
 %%------------------------------------------------------------------------------
-%%% @author Oscar Hellström <oscar@hellstrom.st>
+%%% @author Oscar HellstrÃ¶m <oscar@hellstrom.st>
 %%% @doc Top supervisor for the lhttpc application.
 %%% This is normally started by the application behaviour implemented in
 %%% {@link lhttpc}.


### PR DESCRIPTION
Otherwise compilation fails on Erlang/OTP 17:

ERROR: Failed to extract name from .../lhttpc/src/lhttpc.app.src: {27,
                                                                   file_io_server,
                                                                   invalid_unicode}