### PR TITLE
Reset proxy_setup settings on connection failure

### DIFF
--- a/src/lhttpc.app.src
+++ b/src/lhttpc.app.src
@@ -29,7 +29,7 @@
 %%% @end
 {application, lhttpc,
     [{description, "Lightweight HTTP Client"},
-        {vsn, "1.3.0"},
+        {vsn, "1.3.1"},
         {modules, []},
         {registered, [lhttpc_manager]},
         {applications, [kernel, stdlib, ssl, crypto]},

--- a/src/lhttpc_client.erl
+++ b/src/lhttpc_client.erl
@@ -282,6 +282,7 @@ send_request(State) ->
             lhttpc_sock:close(Socket, Ssl),
             NewState = State#client_state{
                 socket = undefined,
+                proxy_setup = false,
                 attempts = State#client_state.attempts - 1
             },
             send_request(NewState);
@@ -457,6 +458,7 @@ read_response(State, Vsn, {StatusCode, _} = Status, Hdrs) ->
             lhttpc_sock:close(Socket, Ssl),
             NewState = State#client_state{
                 socket = undefined,
+                proxy_setup = false,
                 attempts = State#client_state.attempts - 1
             },
             send_request(NewState);


### PR DESCRIPTION
When using proxy and having issues with connecting to the end service
make sure that the initial proxy handshake is re-run each time to
reconnect.
